### PR TITLE
Fix incorrect position bug

### DIFF
--- a/src/coffee/unsizzle.coffee
+++ b/src/coffee/unsizzle.coffee
@@ -37,16 +37,15 @@ class @unsizzle
         selector = @join node.tagName, node.id, node.classList
 
         if node.parentNode isnt document and @hasSiblings node
-            similar = position = 0
+            similar = 0
 
             for n in node.parentNode.children
                 currentSelector = @join n.tagName, n.id, n.classList
                 similar  += 1 if currentSelector is selector
                 break if n is node
-                position += 1
 
             if similar > 1
-                return selector + ":eq(#{position})"
+                return selector + ":eq(#{similar - 1})"
 
         return selector
 


### PR DESCRIPTION
In cases where the element has siblings, some of whom have the same selector, some don't, ie.

```
div
  span .class1
  span .class2
  span .class2
  span .class1
```

Selecting the third span causes unsizzle to correctly append `:eq(3)`, because it's the fourth child, rather than appending its index among elements of the same selector (which is `similar - 1`).

cc @b-ash 